### PR TITLE
docs: actualizar README principal con estructura de portafolio y enlaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,79 @@
 <div align="center">
   <h1>Hi there 👋 I'm Jose Antonio González Alcántara</h1>
-  <h3>A passionate Python Backend Developer from Spain</h3>
+  <h3>Ingeniero de Software especializado en IA, Cloud Computing y DevOps</h3>
+
+  [![LinkedIn](https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white)](https://linkedin.com/in/jagascripts/)
+  [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/jagaScripts)
+  [![Gmail](https://img.shields.io/badge/Gmail-D14836?style=for-the-badge&logo=gmail&logoColor=white)](mailto:jagascripts@gmail.com)
 </div>
 
-### About me
-- 🔭 Currently building: modern, config‑driven web apps (Fast API, SQL, Flask, Docker, JagaScripts, TypeScripts, Angular, Java)
-- 🌱 Learning more about: clean architectures, CI/CD, and cloud deployments
-- 💬 Ask me about: Python, Flask, Fast API, SQL, Backend basics, Docker, Java, Angular...
-- 😄 Pronouns: he/him 
-- 📫 Reach me: <a href="mailto:jagascripts@gmail.com">jagascripts@gmail.com</a>
+<br>
 
-### Connect with me
-<div align="left">
+Soy **Ingeniero de Software** con más de 4 años de experiencia desarrollando soluciones backend robustas y automatizando procesos críticos. Transformo problemas de negocio complejos en arquitecturas escalables, integrando tecnologías de Machine Learning, bases de datos vectoriales (Qdrant) y LLMs para lograr un impacto real y cuantificable.
 
-[![LinkedIn](https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/jagascripts/)
-[![Gmail](https://img.shields.io/badge/Gmail-D14836?style=for-the-badge&logo=gmail&logoColor=white)](mailto:jagascripts@gmail.com)
+Busco constantemente aplicar la automatización inteligente para reducir tiempos de procesamiento y mejorar la tolerancia a fallos en sistemas corporativos de alto nivel.
 
-</div>
+<br>
 
-### Languages and Tools
+## 📌 Sobre este repositorio (Monorepo)
 
-![Python](https://img.shields.io/badge/-Python-05122A?style=flat&logo=python)
-![Flask](https://img.shields.io/badge/-Flask-05122A?style=flat&logo=flask)
-![JavaScript](https://img.shields.io/badge/-JavaScript-05122A?style=flat&logo=javascript)
-![HTML5](https://img.shields.io/badge/-HTML5-05122A?style=flat&logo=html5)
-![CSS3](https://img.shields.io/badge/-CSS3-05122A?style=flat&logo=css3&logoColor=1572B6)
-![Docker](https://img.shields.io/badge/-Docker-05122A?style=flat&logo=docker)
-![Git](https://img.shields.io/badge/-Git-05122A?style=flat&logo=git)
-![GitHub](https://img.shields.io/badge/-GitHub-05122A?style=flat&logo=github)
-![VS Code](https://img.shields.io/badge/-VS%20Code-05122A?style=flat&logo=visual-studio-code&logoColor=007ACC)
-![Java](https://img.shields.io/badge/-Java-05122A?style=flat&logo=openjdk)
-![TypeScript](https://img.shields.io/badge/-TypeScript-05122A?style=flat&logo=typescript)
-![Angular](https://img.shields.io/badge/-Angular-05122A?style=flat&logo=angular)
-![GitHub Actions](https://img.shields.io/badge/-GitHub%20Actions-05122A?style=flat&logo=githubactions)
-![AWS](https://img.shields.io/badge/-AWS-05122A?style=flat&logo=amazon-aws)
-![Google Cloud](https://img.shields.io/badge/-Google%20Cloud-05122A?style=flat&logo=googlecloud)
-![Azure](https://img.shields.io/badge/-Azure-05122A?style=flat&logo=microsoft-azure)
-![Kubernetes](https://img.shields.io/badge/-Kubernetes-05122A?style=flat&logo=kubernetes)
-![Requests](https://img.shields.io/badge/-Requests-05122A?style=flat)
-![FastAPI](https://img.shields.io/badge/-FastAPI-05122A?style=flat&logo=fastapi)
-![DevOps](https://img.shields.io/badge/-DevOps-05122A?style=flat)
-![Grafana](https://img.shields.io/badge/-Grafana-05122A?style=flat&logo=grafana)
-![Prometheus](https://img.shields.io/badge/-Prometheus-05122A?style=flat&logo=prometheus)
-![Cursor](https://img.shields.io/badge/-Cursor-05122A?style=flat&logo=cursor)
-![GitHub Copilot](https://img.shields.io/badge/-GitHub%20Copilot-05122A?style=flat&logo=githubcopilot)
-![ChatGPT](https://img.shields.io/badge/-ChatGPT-05122A?style=flat&logo=openai)
-![Gemini](https://img.shields.io/badge/-Gemini-05122A?style=flat&logo=googlegemini)
+Este perfil tiene un propósito dual: actúa como portafolio profesional y como un espacio para documentar la aplicación de arquitecturas modernas. Todos los proyectos clave están integrados en este monorepo.
 
+Aquí encontrarás proyectos centrados en:
+- Integración de Inteligencia Artificial (LLMs, Computer Vision, RAG).
+- Construcción de APIs y backend orientados a microservicios.
+- Automatización de infraestructuras y despliegues (DevOps).
 
-### GitHub Stats
+<br>
+
+## 🚀 Proyectos Destacados
+
+He organizado mis proyectos más relevantes clasificados por la etapa formativa en la que fueron desarrollados, demostrando mi evolución desde el desarrollo Full-Stack tradicional hasta la Inteligencia Artificial y arquitecturas Cloud/DevOps.
+
+### 🎓 Máster en IA, Cloud Computing & DevOps (PontIA)
+*Proyectos centrados en Machine Learning, LLMs, arquitecturas de microservicios y despliegues automáticos.*
+
+- **[01. Proyecto Júpiter (TFM - Phishing Detect)](./01_Proyecto_Jupiter)**: Sistema avanzado de detección de amenazas integrando LLMs, bases de datos vectoriales (Qdrant) y orquestación de servicios.
+- **[02. RAG & Bases de Datos Vectoriales](./02_RAG_Vectoriales)**: Implementación de Recuperación Aumentada por Generación utilizando modelos de lenguaje open-source y Qdrant.
+- **[03. Agente de Voz Conversacional (Dialogflow)](./03_Agente_Voz_Conversacional)**: Asistente virtual basado en IA conversacional, automatización de diálogos y síntesis de voz.
+- **[04. API REST de Alto Rendimiento (FastAPI)](./04_API_REST_FastAPI)**: Arquitectura backend en Python aplicando principios SOLID y código limpio.
+
+### 💻 Bootcamp Full-Stack Web (Java & Angular)
+*Proyectos de arquitectura Cliente-Servidor y desarrollo web responsivo.*
+
+- **[05. Portal Web Responsivo (Angular)](./05_Portal_Web_Angular)**: Desarrollo frontend consumiendo APIs RESTful, diseño de componentes y gestión de estado.
+- **[06. API RESTful Backend (Java/Spring Boot)](#)**: *(Pendiente de enlazar/migrar)* - Construcción de la lógica de negocio y persistencia de datos.
+
+### ☕ Curso Superior en Java y Android
+*Fundamentos sólidos en programación orientada a objetos, aplicaciones empresariales y móviles.*
+
+- **[07. Fast Food Company (Java Desktop)](./07_Fast_Food_Company)**: Sistema de gestión empresarial clásico desarrollado nativamente en Java.
+- **[08. Web Agrupados (Java 2 EE)](./08_Web_Agrupados_JEE)**: Aplicación web empresarial construida utilizando servlets, JSP y componentes de PrimeFaces.
+- **[09. App Agrupados (Android)](./09_App_Agrupados_Android)**: Aplicación móvil nativa en Android consumiendo servicios y gestionando layouts complejos.
+
+<br>
+
+## 🛠️ Stack Tecnológico & Herramientas
+
+<p align="left">
+  <img src="https://img.shields.io/badge/-Python-05122A?style=flat&logo=python" alt="Python">
+  <img src="https://img.shields.io/badge/-Java-05122A?style=flat&logo=openjdk" alt="Java">
+  <img src="https://img.shields.io/badge/-TypeScript-05122A?style=flat&logo=typescript" alt="TypeScript">
+  <img src="https://img.shields.io/badge/-Angular-05122A?style=flat&logo=angular" alt="Angular">
+  <img src="https://img.shields.io/badge/-FastAPI-05122A?style=flat&logo=fastapi" alt="FastAPI">
+  <img src="https://img.shields.io/badge/-Docker-05122A?style=flat&logo=docker" alt="Docker">
+  <img src="https://img.shields.io/badge/-Kubernetes-05122A?style=flat&logo=kubernetes" alt="Kubernetes">
+  <img src="https://img.shields.io/badge/-AWS-05122A?style=flat&logo=amazon-aws" alt="AWS">
+  <img src="https://img.shields.io/badge/-Google%20Cloud-05122A?style=flat&logo=googlecloud" alt="Google Cloud">
+  <img src="https://img.shields.io/badge/-Azure-05122A?style=flat&logo=microsoft-azure" alt="Azure">
+  <img src="https://img.shields.io/badge/-GitHub%20Actions-05122A?style=flat&logo=githubactions" alt="GitHub Actions">
+  <img src="https://img.shields.io/badge/-Prometheus-05122A?style=flat&logo=prometheus" alt="Prometheus">
+  <img src="https://img.shields.io/badge/-Grafana-05122A?style=flat&logo=grafana" alt="Grafana">
+</p>
+
+<br>
+
+## 📊 GitHub Stats
 
 <p align="center">
   <a href="https://github.com/JagaScripts">
@@ -56,3 +81,8 @@
     <img height="160" src="https://github-readme-stats-eight-theta.vercel.app/api/top-langs/?username=JagaScripts&layout=compact&langs_count=8&theme=algolia" alt="Top languages" />
   </a>
 </p>
+
+---
+<div align="center">
+  <i>"Optimización de sistemas y procesos mediante automatización e Inteligencia Artificial."</i>
+</div>


### PR DESCRIPTION
Se reemplaza el README antiguo por la nueva propuesta estructurada, categorizando los proyectos por etapa formativa y enlazando las carpetas del monorepo. Se mantiene el stack tecnológico en formato de badges y las estadísticas de GitHub.